### PR TITLE
Fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artem-russkikh/wireproxy-awg
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1


### PR DESCRIPTION
Fixes error
```
go: download go1.23 for darwin/arm64: toolchain not available
```