### PR TITLE
Bump amneziawg-go to v0.2.19 (fix AmneziaWG 1.5 / Amnezia 2.0 handshake loop)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/akamensky/argparse v1.4.0
-	github.com/amnezia-vpn/amneziawg-go v0.2.16
+	github.com/amnezia-vpn/amneziawg-go v0.2.19
 	github.com/go-ini/ini v1.67.0
 	github.com/landlock-lsm/go-landlock v0.6.0
 	github.com/things-go/go-socks5 v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/akamensky/argparse v1.4.0 h1:YGzvsTqCvbEZhL8zZu2AiA5nq805NZh75JNj4ajn1xc=
 github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
-github.com/amnezia-vpn/amneziawg-go v0.2.16 h1:XY6HOq/xtqH8ZXMncRWkjFs85EKdN10NLNnw23kTpE0=
-github.com/amnezia-vpn/amneziawg-go v0.2.16/go.mod h1:nRkPpIzjCxMW8pZKXTRkpqAQVlmFJdVOGkeQSC7wbms=
+github.com/amnezia-vpn/amneziawg-go v0.2.19 h1:l3rOmrA4o5z38kpgnA5iSk1yOm7Cv3AafIi4vxpSEV0=
+github.com/amnezia-vpn/amneziawg-go v0.2.19/go.mod h1:aMgOk9MuX0xI7b5TKAYp8pLM54RlXcOPzDvYw3YEO5A=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=


### PR DESCRIPTION
Fixes #21 (and windtf/wireproxy#205).

Problem: with configs from the current Amnezia client (AmneziaWG 1.5 / "Amnezia 2.0", which set `S4`), the handshake completes (`Received handshake response`) but the tunnel never carries data: `stopped hearing back after 15 seconds` -> endless handshake retries.

Cause: pinned amneziawg-go v0.2.16 does not apply S4 transport padding to keepalive packets, so the keepalive that confirms the session is dropped by the responder on H4 validation, and key confirmation never completes.

Fix: bump github.com/amnezia-vpn/amneziawg-go v0.2.16 -> v0.2.19, which includes:
- f4f4c99 - apply S4 transport padding to keepalive packets (v0.2.18)
- 1cc9427 - handle empty I1-I5 (v0.2.19), covering the "no handshake response at all" variant

The amneziawg-go UAPI config parser is unchanged across these versions, so IPC serialization in wireguard.go stays compatible - dependency bump only, no code changes.

Testing: `go build ./...`, `go vet ./...` and `go test ./...` all pass (go1.26.4).