### PR TITLE
Fix HTTP proxy rejecting non-CONNECT methods (POST, PUT, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ of wireproxy by [@artem-russkikh](https://github.com/artem-russkikh).
 # Feature
 
 - TCP static routing for client and server
-- SOCKS5/HTTP proxy (currently only CONNECT is supported)
+- SOCKS5/HTTP proxy (HTTP proxy supports both CONNECT tunnelling and plain HTTP forwarding)
 
 # TODO
 

--- a/http.go
+++ b/http.go
@@ -114,12 +114,8 @@ func (s *HTTPServer) serve(conn net.Conn) {
 	switch req.Method {
 	case http.MethodConnect:
 		peer, err = s.handleConn(req, conn)
-	case http.MethodGet:
-		peer, err = s.handle(req)
 	default:
-		_ = responseWith(req, http.StatusMethodNotAllowed).Write(conn)
-		log.Printf("unsupported protocol: %s\n", req.Method)
-		return
+		peer, err = s.handle(req)
 	}
 	if err != nil {
 		log.Printf("dial proxy failed: %s\n", err)

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,145 @@
+package wireproxy
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHTTPServePlainPostForwarded verifies that a plain (non-CONNECT) HTTP
+// request such as POST is forwarded to the upstream peer with its method,
+// target and body intact, instead of being rejected as an unsupported method
+// (regression test for issue #27).
+func TestHTTPServePlainPostForwarded(t *testing.T) {
+	// upstream is the fake origin server the proxy dials into.
+	upstreamClient, upstream := net.Pipe()
+
+	s := &HTTPServer{
+		config: &HTTPConfig{},
+		dial: func(network, address string) (net.Conn, error) {
+			if want := "example.com:80"; address != want {
+				t.Errorf("dial address = %q, want %q", address, want)
+			}
+			return upstreamClient, nil
+		},
+	}
+
+	// client talks to the proxy through an in-memory connection.
+	clientConn, proxyConn := net.Pipe()
+
+	go s.serve(proxyConn)
+
+	// Client sends a plain HTTP POST with a body, proxy-style (absolute URI).
+	go func() {
+		_, _ = clientConn.Write([]byte(
+			"POST http://example.com/api HTTP/1.1\r\n" +
+				"Host: example.com\r\n" +
+				"Content-Length: 5\r\n" +
+				"\r\n" +
+				"hello"))
+	}()
+
+	_ = upstream.SetReadDeadline(time.Now().Add(5 * time.Second))
+	forwarded, err := http.ReadRequest(bufio.NewReader(upstream))
+	if err != nil {
+		t.Fatalf("upstream did not receive forwarded request: %v", err)
+	}
+
+	if forwarded.Method != http.MethodPost {
+		t.Errorf("forwarded method = %q, want POST", forwarded.Method)
+	}
+	if forwarded.URL.Path != "/api" {
+		t.Errorf("forwarded path = %q, want /api", forwarded.URL.Path)
+	}
+
+	body := make([]byte, 5)
+	if _, err := upstream.Read(body); err != nil {
+		t.Fatalf("reading forwarded body: %v", err)
+	}
+	if got := string(body); got != "hello" {
+		t.Errorf("forwarded body = %q, want %q", got, "hello")
+	}
+
+	_ = upstream.Close()
+	_ = clientConn.Close()
+}
+
+// TestHTTPServeConnectStillTunnels verifies the CONNECT path is unchanged: the
+// proxy answers "200 Connection established" and then tunnels bytes.
+func TestHTTPServeConnectStillTunnels(t *testing.T) {
+	upstreamClient, upstream := net.Pipe()
+
+	s := &HTTPServer{
+		config: &HTTPConfig{},
+		dial: func(network, address string) (net.Conn, error) {
+			if want := "example.com:443"; address != want {
+				t.Errorf("dial address = %q, want %q", address, want)
+			}
+			return upstreamClient, nil
+		},
+	}
+
+	clientConn, proxyConn := net.Pipe()
+	go s.serve(proxyConn)
+
+	go func() {
+		_, _ = clientConn.Write([]byte(
+			"CONNECT example.com:443 HTTP/1.1\r\n" +
+				"Host: example.com:443\r\n" +
+				"\r\n"))
+	}()
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("reading CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+
+	_ = upstream.Close()
+	_ = clientConn.Close()
+}
+
+func TestHTTPServePlainPostNotRejected(t *testing.T) {
+	// Guard: a POST must not produce a 405 Method Not Allowed back to the client.
+	dialed := make(chan struct{}, 1)
+	s := &HTTPServer{
+		config: &HTTPConfig{},
+		dial: func(network, address string) (net.Conn, error) {
+			dialed <- struct{}{}
+			c, _ := net.Pipe()
+			return c, nil
+		},
+	}
+
+	clientConn, proxyConn := net.Pipe()
+	go s.serve(proxyConn)
+
+	go func() {
+		_, _ = clientConn.Write([]byte(
+			"POST http://example.com/ HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"))
+	}()
+
+	select {
+	case <-dialed:
+		// Reaching dial proves the request was routed to handle(), not rejected.
+	case <-time.After(5 * time.Second):
+		t.Fatal("POST was not forwarded to upstream (likely rejected as unsupported method)")
+	}
+
+	// Sanity: ensure no 405 response leaked back to the client before dial.
+	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	buf := make([]byte, 64)
+	if n, _ := clientConn.Read(buf); n > 0 {
+		if strings.Contains(string(buf[:n]), "405") {
+			t.Errorf("client received a 405 response: %q", string(buf[:n]))
+		}
+	}
+
+	_ = clientConn.Close()
+}


### PR DESCRIPTION
## Problem

Fixes #27.

The HTTP proxy (`[http]` section) only handled `CONNECT` (HTTPS tunnelling) and `GET`. Every other method — `POST`, `PUT`, `HEAD`, `DELETE`, … — fell into the `switch` `default` branch in `HTTPServer.serve()`, which replied `405 Method Not Allowed` and logged `unsupported protocol: <METHOD>`. That's exactly what was reported when using it as an HTTP Telegram proxy ("`POST` is an unsupported protocol").

## Fix

Route all non-`CONNECT` methods through the existing plain-HTTP forwarding path (`handle()` → `req.Write(peer)`), which already serializes the full request including the body, so it works for any method. The method switch was simply too narrow:

```go
switch req.Method {
case http.MethodConnect:
    peer, err = s.handleConn(req, conn)
default:
    peer, err = s.handle(req)
}
```

## Tests

Adds `http_test.go` with three regression tests (green under `-race`):

- `TestHTTPServePlainPostForwarded` — a plain `POST` reaches the upstream with its method, path and body intact.
- `TestHTTPServeConnectStillTunnels` — `CONNECT` still returns `200 Connection established`.
- `TestHTTPServePlainPostNotRejected` — a `POST` is dialled out and no `405` leaks back to the client.

`go build ./...`, `go vet ./...` and `go test -race ./...` all pass. Also updates the README feature line that incorrectly said the HTTP proxy only supports `CONNECT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
