### PR TITLE
fix: implement sandbox per platform to avoid landlock on android

### DIFF
--- a/cmd/wireproxy/main.go
+++ b/cmd/wireproxy/main.go
@@ -3,20 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/landlock-lsm/go-landlock/landlock"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"github.com/akamensky/argparse"
 	"github.com/amnezia-vpn/amneziawg-go/v3/device"
 	wireproxyawg "github.com/artem-russkikh/wireproxy-awg"
-	"suah.dev/protect"
 )
 
 // an argument to denote that this process was spawned by -d
@@ -29,24 +25,6 @@ var default_config_paths = []string {
 }
 
 var version = "1.0.18-dev"
-
-func panicIfError(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-// attempts to pledge and panic if it fails
-// this does nothing on non-OpenBSD systems
-func pledgeOrPanic(promises string) {
-	panicIfError(protect.Pledge(promises))
-}
-
-// attempts to unveil and panic if it fails
-// this does nothing on non-OpenBSD systems
-func unveilOrPanic(path string, flags string) {
-	panicIfError(protect.Unveil(path, flags))
-}
 
 // get the executable path via syscalls or infer it from argv
 func executablePath() string {
@@ -67,91 +45,6 @@ func configFilePath() (string, bool) {
     return "", false
 }
 
-func lock(stage string) {
-	switch stage {
-	case "boot":
-		exePath := executablePath()
-		// OpenBSD
-		unveilOrPanic("/", "r")
-		unveilOrPanic(exePath, "x")
-		// only allow standard stdio operation, file reading, networking, and exec
-		// also remove unveil permission to lock unveil
-		pledgeOrPanic("stdio rpath inet dns proc exec")
-		// Linux
-		panicIfError(landlock.V1.BestEffort().RestrictPaths(
-			landlock.RODirs("/"),
-		))
-	case "boot-daemon":
-	case "read-config":
-		// OpenBSD
-		pledgeOrPanic("stdio rpath inet dns")
-	case "ready":
-		// no file access is allowed from now on, only networking
-		// OpenBSD
-		pledgeOrPanic("stdio inet dns")
-		// Linux
-		net.DefaultResolver.PreferGo = true // needed to lock down dependencies
-		panicIfError(landlock.V1.BestEffort().RestrictPaths(
-			landlock.ROFiles("/etc/resolv.conf").IgnoreIfMissing(),
-			landlock.ROFiles("/dev/fd").IgnoreIfMissing(),
-			landlock.ROFiles("/dev/zero").IgnoreIfMissing(),
-			landlock.ROFiles("/dev/urandom").IgnoreIfMissing(),
-			landlock.ROFiles("/etc/localtime").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/self/stat").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/self/status").IgnoreIfMissing(),
-			landlock.ROFiles("/usr/share/locale").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/self/cmdline").IgnoreIfMissing(),
-			landlock.ROFiles("/usr/share/zoneinfo").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/sys/kernel/version").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/sys/kernel/ngroups_max").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/sys/kernel/cap_last_cap").IgnoreIfMissing(),
-			landlock.ROFiles("/proc/sys/vm/overcommit_memory").IgnoreIfMissing(),
-			landlock.RWFiles("/dev/log").IgnoreIfMissing(),
-			landlock.RWFiles("/dev/null").IgnoreIfMissing(),
-			landlock.RWFiles("/dev/full").IgnoreIfMissing(),
-			landlock.RWFiles("/proc/self/fd").IgnoreIfMissing(),
-		))
-	default:
-		panic("invalid stage")
-	}
-}
-
-func extractPort(addr string) uint16 {
-	_, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		panic(fmt.Errorf("failed to extract port from %s: %w", addr, err))
-	}
-
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		panic(fmt.Errorf("failed to extract port from %s: %w", addr, err))
-	}
-
-	return uint16(port)
-}
-
-func lockNetwork(sections []wireproxyawg.RoutineSpawner, infoAddr *string) {
-	var rules []landlock.Rule
-	if infoAddr != nil && *infoAddr != "" {
-		rules = append(rules, landlock.BindTCP(extractPort(*infoAddr)))
-	}
-
-	for _, section := range sections {
-		switch section := section.(type) {
-		case *wireproxyawg.TCPServerTunnelConfig:
-			rules = append(rules, landlock.ConnectTCP(extractPort(section.Target)))
-		case *wireproxyawg.HTTPConfig:
-			rules = append(rules, landlock.BindTCP(extractPort(section.BindAddress)))
-		case *wireproxyawg.TCPClientTunnelConfig:
-			rules = append(rules, landlock.ConnectTCP(uint16(section.BindAddress.Port)))
-		case *wireproxyawg.Socks5Config:
-			rules = append(rules, landlock.BindTCP(extractPort(section.BindAddress)))
-		}
-	}
-
-	panicIfError(landlock.V4.BestEffort().RestrictNet(rules...))
-}
-
 func main() {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGINT, syscall.SIGQUIT)
@@ -163,12 +56,14 @@ func main() {
 	}()
 
 	exePath := executablePath()
-	lock("boot")
+
+	sandbox := &wireproxyawg.Sandbox{}
+	sandbox.Lock("boot")
 
 	isDaemonProcess := len(os.Args) > 1 && os.Args[1] == daemonProcess
 	args := os.Args
 	if isDaemonProcess {
-		lock("boot-daemon")
+		sandbox.Lock("boot-daemon")
 		args = []string{args[0]}
 		args = append(args, os.Args[2:]...)
 	}
@@ -202,7 +97,7 @@ func main() {
 	}
 
 	if !*daemon {
-		lock("read-config")
+		sandbox.Lock("read-config")
 	}
 
 	conf, err := wireproxyawg.ParseConfig(*config)
@@ -215,7 +110,7 @@ func main() {
 		return
 	}
 
-	lockNetwork(conf.Routines, info)
+	sandbox.LockNetwork(conf.Routines, info)
 
 	if isDaemonProcess {
 		os.Stdout, _ = os.Open(os.DevNull)
@@ -242,7 +137,7 @@ func main() {
 		logLevel = device.LogLevelSilent
 	}
 
-	lock("ready")
+	sandbox.Lock("ready")
 
 	tun, err := wireproxyawg.StartWireguard(conf.Device, logLevel)
 	if err != nil {

--- a/sandbox.go
+++ b/sandbox.go
@@ -1,0 +1,4 @@
+package wireproxy
+
+type Sandbox struct {
+}

--- a/sandbox_android.go
+++ b/sandbox_android.go
@@ -1,0 +1,13 @@
+//go:build android && arm64
+
+package wireproxy
+
+import "log"
+
+func (config *Sandbox) Lock(stage string) {
+	log.Printf("sanboxing is not supported on android")
+}
+
+func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+	log.Printf("network sanboxing is not supported on android")
+}

--- a/sandbox_android.go
+++ b/sandbox_android.go
@@ -4,10 +4,10 @@ package wireproxy
 
 import "log"
 
-func (config *Sandbox) Lock(stage string) {
+func (sb *Sandbox) Lock(stage string) {
 	log.Printf("sanboxing is not supported on android")
 }
 
-func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+func (sb *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
 	log.Printf("network sanboxing is not supported on android")
 }

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/landlock-lsm/go-landlock/landlock"
 )
 
-func (config *Sandbox) Lock(stage string) {
+func (sb *Sandbox) Lock(stage string) {
 	switch stage {
 	case "boot":
 		if err := landlock.V1.BestEffort().RestrictPaths(landlock.RODirs("/")); err != nil {
@@ -65,7 +65,7 @@ func extractPort(addr string) uint16 {
 	return uint16(port)
 }
 
-func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+func (sb *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
 	var rules []landlock.Rule
 	if infoAddr != nil && *infoAddr != "" {
 		rules = append(rules, landlock.BindTCP(extractPort(*infoAddr)))

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -1,0 +1,90 @@
+//go:build linux && !android
+
+package wireproxy
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/landlock-lsm/go-landlock/landlock"
+)
+
+func (config *Sandbox) Lock(stage string) {
+	switch stage {
+	case "boot":
+		if err := landlock.V1.BestEffort().RestrictPaths(landlock.RODirs("/")); err != nil {
+			panic(err)
+		}
+	case "boot-daemon":
+	case "read-config":
+	case "ready":
+		// no file access is allowed from now on, only networking
+		net.DefaultResolver.PreferGo = true // needed to lock down dependencies
+
+		rules := []landlock.Rule{
+			landlock.ROFiles("/etc/resolv.conf").IgnoreIfMissing(),
+			landlock.ROFiles("/dev/fd").IgnoreIfMissing(),
+			landlock.ROFiles("/dev/zero").IgnoreIfMissing(),
+			landlock.ROFiles("/dev/urandom").IgnoreIfMissing(),
+			landlock.ROFiles("/etc/localtime").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/self/stat").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/self/status").IgnoreIfMissing(),
+			landlock.ROFiles("/usr/share/locale").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/self/cmdline").IgnoreIfMissing(),
+			landlock.ROFiles("/usr/share/zoneinfo").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/sys/kernel/version").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/sys/kernel/ngroups_max").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/sys/kernel/cap_last_cap").IgnoreIfMissing(),
+			landlock.ROFiles("/proc/sys/vm/overcommit_memory").IgnoreIfMissing(),
+			landlock.RWFiles("/dev/log").IgnoreIfMissing(),
+			landlock.RWFiles("/dev/null").IgnoreIfMissing(),
+			landlock.RWFiles("/dev/full").IgnoreIfMissing(),
+			landlock.RWFiles("/proc/self/fd").IgnoreIfMissing(),
+		}
+
+		if err := landlock.V1.BestEffort().RestrictPaths(rules...); err != nil {
+			panic(err)
+		}
+	default:
+		panic("invalid stage")
+	}
+}
+
+func extractPort(addr string) uint16 {
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		panic(fmt.Errorf("failed to extract port from %s: %w", addr, err))
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		panic(fmt.Errorf("failed to extract port from %s: %w", addr, err))
+	}
+
+	return uint16(port)
+}
+
+func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+	var rules []landlock.Rule
+	if infoAddr != nil && *infoAddr != "" {
+		rules = append(rules, landlock.BindTCP(extractPort(*infoAddr)))
+	}
+
+	for _, section := range sections {
+		switch section := section.(type) {
+		case *TCPServerTunnelConfig:
+			rules = append(rules, landlock.ConnectTCP(extractPort(section.Target)))
+		case *HTTPConfig:
+			rules = append(rules, landlock.BindTCP(extractPort(section.BindAddress)))
+		case *TCPClientTunnelConfig:
+			rules = append(rules, landlock.ConnectTCP(uint16(section.BindAddress.Port)))
+		case *Socks5Config:
+			rules = append(rules, landlock.BindTCP(extractPort(section.BindAddress)))
+		}
+	}
+
+	if err := landlock.V4.BestEffort().RestrictNet(rules...); err != nil {
+		panic(err)
+	}
+}

--- a/sandbox_openbsd.go
+++ b/sandbox_openbsd.go
@@ -18,7 +18,7 @@ func executablePath() string {
 	return programPath
 }
 
-func (config *Sandbox) Lock(stage string) {
+func (sb *Sandbox) Lock(stage string) {
 	switch stage {
 	case "boot":
 		exePath := executablePath()
@@ -51,6 +51,6 @@ func (config *Sandbox) Lock(stage string) {
 	}
 }
 
-func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+func (sb *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
 	log.Printf("network sanboxing is not supported on OpenBSD")
 }

--- a/sandbox_openbsd.go
+++ b/sandbox_openbsd.go
@@ -1,0 +1,56 @@
+//go:build openbsd
+
+package wireproxy
+
+import (
+	"log"
+	"os"
+
+	"suah.dev/protect"
+)
+
+// get the executable path via syscalls or infer it from argv
+func executablePath() string {
+	programPath, err := os.Executable()
+	if err != nil {
+		return os.Args[0]
+	}
+	return programPath
+}
+
+func (config *Sandbox) Lock(stage string) {
+	switch stage {
+	case "boot":
+		exePath := executablePath()
+
+		if err := protect.Unveil("/", "r"); err != nil {
+			panic(err)
+		}
+
+		if err := protect.Unveil(exePath, "x"); err != nil {
+			panic(err)
+		}
+
+		// only allow standard stdio operation, file reading, networking, and exec
+		// also remove unveil permission to lock unveil
+		if err := protect.Pledge("stdio rpath inet dns proc exec"); err != nil {
+			panic(err)
+		}
+	case "boot-daemon":
+	case "read-config":
+		if err := protect.Pledge("stdio rpath inet dns"); err != nil {
+			panic(err)
+		}
+	case "ready":
+		// no file access is allowed from now on, only networking
+		if err := protect.Pledge("stdio inet dns"); err != nil {
+			panic(err)
+		}
+	default:
+		panic("invalid stage")
+	}
+}
+
+func (config *Sandbox) LockNetwork(sections []RoutineSpawner, infoAddr *string) {
+	log.Printf("network sanboxing is not supported on OpenBSD")
+}


### PR DESCRIPTION
## Summary

Implement sandbox separately for each platform to prevent Android from using Linux Landlock.

## Problem

The current sandbox implementation relies on Landlock. While Landlock is available on Linux, it is not available on most Android devices, and even when the kernel supports it, it is generally not accessible on consumer Android devices.

As a result, running wireproxy with the sandbox enabled on Android causes it to panic with a Landlock-related error, making the program effectively unusable on Android/Termux.

Termux currently works around this by removing the sandbox entirely with a patch:
https://github.com/termux/termux-packages/blob/master/packages/wireproxy/0001-drop-sandbox.patch

## Fix

Move the sandbox implementation behind platform-specific build constraints:

* Keep the existing Landlock-based implementation for supported platforms.
* Provide an Android-specific implementation that does not use Landlock.
* Restrict the Android implementation to `arm64`, as the required argparse dependency does not support `android/386`.

Build tags are used instead of runtime platform checks so the Android build does not contain the Landlock implementation and its dependencies at all. Since that code can never be used on Android, excluding it at build time avoids carrying unnecessary dead code and platform-specific dependencies into the Android binary.
